### PR TITLE
Get the Windows build to actually fail when it fails

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,20 +92,27 @@ task:
     - Invoke-WebRequest https://releases.wezm.net/upload-to-s3/0.1.10/upload-to-s3-0.1.10-x86_64-pc-windows-msvc.zip -OutFile upload-to-s3.zip
     - Expand-Archive upload-to-s3.zip -DestinationPath .
     - git fetch --tags
-  test_script:
-    - ~\.cargo\bin\cargo test
+  test_script: |
+    # PowerShell it truly horrific and lacks a way to exit on external command failure so we have to check after every command
+    # https://stackoverflow.com/questions/48864988/powershell-with-git-command-error-handling-automatically-abort-on-non-zero-exi/48877892#48877892
+    ~\.cargo\bin\cargo test
+    if ($LASTEXITCODE) { Throw }
   publish_script: |
     try {
       $tag=$(git describe --exact-match HEAD 2>$null)
+      if ($LASTEXITCODE) { Throw }
     } catch {
       $tag=""
     }
     if ( $tag.Length -gt 0 ) {
       ~\.cargo\bin\cargo build --release --locked
+      if ($LASTEXITCODE) { Throw }
       $tarball="rsspls-$tag-x86_64-pc-windows-msvc.zip"
       cd target\release
       strip rsspls.exe
+      if ($LASTEXITCODE) { Throw }
       Compress-Archive .\rsspls.exe "$tarball"
       cd ..\..
       .\upload-to-s3 -b releases.wezm.net "target\release\$tarball" "rsspls/$tag/$tarball"
+      if ($LASTEXITCODE) { Throw }
     }


### PR DESCRIPTION
PowerShell it truly horrific and lacks a way to exit on external command failure so we have to check after every command.

https://stackoverflow.com/questions/48864988/powershell-with-git-command-error-handling-automatically-abort-on-non-zero-exi/48877892#48877892
