### PR TITLE
Rewrite URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "simple-eyre",
  "tokio",
  "toml",
+ "url",
  "xdg",
 ]
 
@@ -1300,18 +1301,18 @@ checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,9 @@ pico-args = "0.5.0"
 pretty_env_logger = "0.4.0"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "gzip"] }
 rss = "2.0.1"
-serde = { version = "1.0.137", features = ["derive"] }
+serde = { version = "1.0.138", features = ["derive"] }
 simple-eyre = "0.3.1"
 tokio = { version = "1.19.2", features = ["rt-multi-thread", "macros"] }
 toml = "0.5.9"
+url = "2.2.2"
 xdg = "2.4.1"


### PR DESCRIPTION
Make sure that URLs in RSS `<link>` elements are absolute and also rewrite URLs without a base in the HTML. 

Fixes #5 