### PR TITLE
Track a digest of the configuration file in the cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptoxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
+
+[[package]]
 name = "cssparser"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1321,7 @@ dependencies = [
  "atomicwrites",
  "basic-toml",
  "chrono",
+ "cryptoxide",
  "dirs",
  "futures",
  "kuchiki",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +693,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +895,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "never"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +968,50 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -1049,6 +1138,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "powerfmt"
@@ -1259,10 +1354,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1274,6 +1371,7 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
  "tokio-util",
@@ -1405,6 +1503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1525,29 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1766,6 +1896,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +2024,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4.21"
 mime_guess = { version = "2.0.4", default-features = false }
 pico-args = "0.5.0"
 pretty_env_logger = "0.5.0"
-reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls", "gzip", "socks"] }
+reqwest = { version = "0.11.24", default-features = false, features = ["gzip", "socks"] }
 rss = "2.0.7"
 serde = { version = "1.0.197", features = ["derive"] }
 simple-eyre = "0.3.1"
@@ -46,3 +46,11 @@ dirs = "5.0.1"
 
 [target.'cfg(not(windows))'.dependencies]
 xdg = "2.5.2"
+
+[profile.release]
+strip = "debuginfo"
+
+[features]
+default = ["rust-tls"]
+native-tls = ["reqwest/native-tls"]
+rust-tls = ["reqwest/rustls-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ anydate = "0.4.0"
 atomicwrites = "0.4.3"
 basic-toml = "0.1.8"
 chrono = { version = "0.4.35", default-features = false }
+cryptoxide = { version = "0.4.4", features = ["blake2"], default-features = false }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 kuchiki = "0.8.1"
 log = "0.4.21"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,11 +6,13 @@ use log::debug;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 
+use crate::config::ConfigHash;
+
 #[derive(Debug, Serialize)]
 pub struct RequestCacheWrite<'a> {
     pub headers: Vec<(&'a str, &'a str)>,
     pub version: &'a str,
-    pub config_hash: &'a str,
+    pub config_hash: ConfigHash<'a>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -32,7 +34,7 @@ struct RequestCacheRead {
 
 pub fn deserialise_cached_headers(
     path: &Path,
-    config_hash: &str,
+    config_hash: ConfigHash<'_>,
 ) -> Option<HeaderMap<HeaderValue>> {
     let raw = fs::read(path).ok()?;
     let cache: RequestCacheRead = toml::from_slice(&raw).ok()?;
@@ -45,7 +47,7 @@ pub fn deserialise_cached_headers(
             path.display()
         );
         return None;
-    } else if cache.config_hash.as_deref() != Some(config_hash) {
+    } else if cache.config_hash.as_deref() != Some(config_hash.0) {
         debug!(
             "cache config hash mismatch ({:?}) != ({:?}), ignoring cache at: {}",
             cache.config_hash,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,10 +8,13 @@ use basic_toml as toml;
 use cryptoxide::{blake2b::Blake2b, digest::Digest};
 use eyre::WrapErr;
 use log::{debug, warn};
-use serde::{de, Deserialize, Deserializer};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use simple_eyre::eyre;
 use time::format_description::OwnedFormatItem;
 use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+#[derive(Debug, Eq, PartialEq, Serialize, Clone, Copy)]
+pub struct ConfigHash<'a>(pub &'a str);
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -27,6 +27,7 @@ pub enum ProcessResult {
 pub async fn process_feed(
     client: &Client,
     channel_config: &ChannelConfig,
+    config_hash: &str,
     cached_headers: &Option<HeaderMap>,
 ) -> eyre::Result<ProcessResult> {
     let config = &channel_config.config;
@@ -81,6 +82,7 @@ pub async fn process_feed(
     let map = RequestCacheWrite {
         headers,
         version: crate::version(),
+        config_hash,
     };
     let serialised_headers = toml::to_string(&map)
         .map_err(|err| warn!("unable to serialise headers: {}", err))

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -14,7 +14,7 @@ use time::OffsetDateTime;
 use url::Url;
 
 use crate::cache::RequestCacheWrite;
-use crate::config::{ChannelConfig, DateConfig, FeedConfig};
+use crate::config::{ChannelConfig, ConfigHash, DateConfig, FeedConfig};
 
 pub enum ProcessResult {
     NotModified,
@@ -27,7 +27,7 @@ pub enum ProcessResult {
 pub async fn process_feed(
     client: &Client,
     channel_config: &ChannelConfig,
-    config_hash: &str,
+    config_hash: ConfigHash<'_>,
     cached_headers: &Option<HeaderMap>,
 ) -> eyre::Result<ProcessResult> {
     let config = &channel_config.config;


### PR DESCRIPTION
This enables ignoring the cache when the configuration has changed, ensuring that the feeds are regenerated.

Fixes #45 